### PR TITLE
Snap: Add back SCENE_MODE_HDR_INT definition

### DIFF
--- a/src/com/android/camera/SettingsManager.java
+++ b/src/com/android/camera/SettingsManager.java
@@ -99,6 +99,7 @@ public class SettingsManager implements ListMenu.SettingsListener {
 
     public static final int SCENE_MODE_AUTO_INT = 0;
     public static final int SCENE_MODE_NIGHT_INT = 5;
+    public static final int SCENE_MODE_HDR_INT = 18;
 
     public static final int TALOS_SOCID = 355;
     public static final int MOOREA_SOCID = 365;


### PR DESCRIPTION
```
/home/oem/xtended/out/target/common/obj/APPS/Snap_intermediates/classes -type f | sort | build/soong/scripts/jar-args.sh /home/oem/xtended/out/target/common/obj/APPS/Snap_intermediates/classes; echo \"-C /home/oem/xtended/out/empty .\") )"
packages/apps/Snap/src/com/android/camera/CaptureModule.java:4007: error: cannot find symbol
                && mode != SettingsManager.SCENE_MODE_HDR_INT)
                                          ^
  symbol:   variable SCENE_MODE_HDR_INT
  location: class SettingsManager
1 error
```